### PR TITLE
Add a command line utility for generating and inspecting ULID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ bencher = "0.1"
 name = "bench"
 path = "benches/bench.rs"
 harness = false
+
+[workspace]
+members = ["cli"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ulid-cli"
+version = "0.3.0"
+authors = ["dylanhart <dylan96hart@gmail.com>", "Kan-Ru Chen <kanru@kanru.info>"]
+
+license = "MIT"
+readme = "../README.md"
+
+description = "A command line interface for generating and inspecting ULIDs"
+keywords = ["ulid", "uuid", "sortable", "identifier"]
+
+repository = "https://github.com/dylanhart/ulid-rs"
+
+edition = "2018"
+
+[dependencies]
+structopt = "0.2"
+ulid = { version = "*", path = ".." }

--- a/cli/src/bin/ulid.rs
+++ b/cli/src/bin/ulid.rs
@@ -1,0 +1,67 @@
+extern crate structopt;
+
+use std::io::{self, Write};
+use ulid::Ulid;
+
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// Number of ULIDs to generate
+    #[structopt(short = "n", long = "count", default_value = "1")]
+    count: u32,
+    /// ULIDs for inspection
+    #[structopt(conflicts_with = "count")]
+    ulids: Vec<String>,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+
+    if !opt.ulids.is_empty() {
+        inspect(&opt.ulids);
+    } else {
+        generate(opt.count);
+    }
+}
+
+fn generate(count: u32) {
+    let stdout = io::stdout();
+    let mut locked = stdout.lock();
+    for _ in 0..count {
+        writeln!(&mut locked, "{}", Ulid::new()).unwrap();
+    }
+}
+
+fn inspect(values: &[String]) {
+    for val in values {
+        let ulid = Ulid::from_string(&val);
+        match ulid {
+            Ok(ulid) => {
+                let upper_hex = format!("{:X}", ulid.0);
+                println!(
+                    "
+REPRESENTATION:
+
+  String: {}
+     Raw: {}
+
+COMPONENTS:
+
+       Time: {}
+  Timestamp: {}
+    Payload: {}
+",
+                    ulid.to_string(),
+                    upper_hex,
+                    ulid.datetime().to_rfc2822(),
+                    ulid.timestamp_ms(),
+                    upper_hex.chars().skip(6).collect::<String>()
+                );
+            }
+            Err(e) => {
+                println!("{} is not a valid ULID: {}", val, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Inspired by the command line utility provided by KSuid.

Example output:
```
$ ulid 
01D2529RQR339XEN9CVDZX7M79

$ ulid -n 3
01D252A4NST5SKTW2ZS4F29F0Y
01D252A4NSXBWFBXMHEG293W1R
01D252A4NSC2E580RMCWJF7R8B

$ ulid 01D2529RQR339XEN9CVDZX7M79

REPRESENTATION:

  String: 01D2529RQR339XEN9CVDZX7M79
     Raw: 1688A24E2F818D3D7552CDB7FD3D0E9

COMPONENTS:

       Time: Sat, 26 Jan 2019 12:31:39 +0000
  Timestamp: 1548505899768
    Payload: 4E2F818D3D7552CDB7FD3D0E9
```