### PR TITLE
Add optional features to support serde and UUID conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/dylanhart/ulid-rs"
 chrono = "0.4"
 lazy_static = "1.2"
 rand = "0.6"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4"
 lazy_static = "1.2"
 rand = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
+uuid = { version = "0.8", optional = true }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ assert_eq!(ulid, res.unwrap());
 
 [ulid]: https://github.com/alizain/ulid
 
+## Optional features
+
+* **`serde`**: Enables serialization and deserialization of `Ulid` types via `serde`. ULIDs are serialized using their canonical 26-character representation as defined in the ULID standard. An optional `ulid_as_u128` module is provided, which enables serialization through an `Ulid`'s inner `u128` primitive type. See the [documentation](https://docs.rs/ulid/latest/ulid/serde/index.html) and [serde docs](https://serde.rs/field-attrs.html#with) for more information.
+* **`uuid`**: Implements infallible conversions between ULIDs and UUIDs from the [`uuid`](https://github.com/uuid-rs/uuid) crate via the [`std::convert::From`](https://doc.rust-lang.org/std/convert/trait.From.html) trait.
+
 ## Benchmark
 
 Benchmarks were run on my laptop. Run them yourself with `cargo bench`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@
 use rand;
 
 mod base32;
+#[cfg(feature = "serde")]
+pub mod serde;
 
 use chrono::prelude::{DateTime, TimeZone, Utc};
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ use rand;
 mod base32;
 #[cfg(feature = "serde")]
 pub mod serde;
+#[cfg(feature = "uuid")]
+mod uuid;
 
 use chrono::prelude::{DateTime, TimeZone, Utc};
 use std::fmt;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,69 @@
+//! Serialization and deserialization.
+//!
+//! By default, serialization and deserialization go through ULID's 26-character
+//! canonical string representation as set by the ULID standard.
+//!
+//! ULIDs can optionally be serialized as u128 integers using the `ulid_as_u128`
+//! module. See the module's documentation for examples.
+
+use crate::Ulid;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+impl Serialize for Ulid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Ulid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let deserialized_str = String::deserialize(deserializer)?;
+        Self::from_string(&deserialized_str).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Serialization and deserialization of ULIDs through their inner u128 type.
+///
+/// To use it, annotate a field with
+/// `#[serde(with = "ulid_as_u128")]`,
+/// `#[serde(serialize_with = "ulid_as_u128")]`, or
+/// `#[serde(deserialize_with = "ulid_as_u128")]`.
+///
+/// # Examples
+/// ```
+/// # use ulid::Ulid;
+/// # use ulid::serde::ulid_as_u128;
+/// # use serde::{Serialize, Deserialize};
+/// #[derive(Serialize, Deserialize)]
+/// struct U128Example {
+///     #[serde(with = "ulid_as_u128")]
+///     identifier: Ulid
+/// }
+/// ```
+pub mod ulid_as_u128 {
+    use crate::Ulid;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serializes a ULID as a u128 type.
+    pub fn serialize<S>(value: &Ulid, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.0.serialize(serializer)
+    }
+
+    /// Deserializes a ULID from a u128 type.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Ulid, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let deserialized_u128 = u128::deserialize(deserializer)?;
+        Ok(Ulid(deserialized_u128))
+    }
+}

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,0 +1,15 @@
+//! Conversions between ULID and UUID.
+
+use crate::Ulid;
+use uuid::Uuid;
+
+impl From<Uuid> for Ulid {
+    fn from(uuid: Uuid) -> Self {
+        Ulid(uuid.as_u128())
+    }
+}
+impl From<Ulid> for Uuid {
+    fn from(ulid: Ulid) -> Self {
+        Uuid::from_u128(ulid.0)
+    }
+}


### PR DESCRIPTION
(I decided to open a single PR for both features, let me know if you'd prefer separate PRs)

This PR adds:
* `serde` as an optional dependency.  
  When enabled, `Serialize` and `Deserialize` are implemented for `Ulid`s through their Crockford 26-char string representation.
  * Plus, a convenience serialization module `ulid::serde::ulid_as_u128` that can be used to serialize directly through the inner `u128` instead of a string.
* `uuid` as an optional dependency.  
  When enabled, it implements `From<Ulid> for Uuid` and `From<Uuid> for Ulid`. Both go though the types' inner `u128` representations and should be infallible.
  * Plus, when `serde` is also enabled, a convenience serialization module `ulid::serde::ulid_as_uuid` that can be used to serialize the ULID as a UUID string (and vice-versa). This is a bit of a niche feature, but it comes in handy when you're working with, say, a stringly-typed REST API that expects UUID-formatted identifiers, but one's using ULIDs internally.
* A section to the `README.md` describing the new features.

Closes #23.