### PR TITLE
Tell docs.rs to document all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ harness = false
 
 [workspace]
 members = ["cli"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Docs.rs doesn't build optional features by default. With this change the docs for the new features should show up.

(should also fix an inadvertently-broken link in the readme, my bad)