### PR TITLE
switch from time to systemtime

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - run: cargo check --package ulid-cli
       - run: cargo test
       - run: cargo test --all-features
       - run: cargo test --no-default-features --features=std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ repository = "https://github.com/dylanhart/ulid-rs"
 
 [features]
 default = ["std"]
-std = ["rand", "time"]
+std = ["rand"]
+time = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 rand = { version = "0.8", optional = true }
 # -- Sync versions with the WASM target below --
-time = { version = "0.3", optional = true }
 uuid = { version = "1.1", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ repository = "https://github.com/dylanhart/ulid-rs"
 [features]
 default = ["std"]
 std = ["rand"]
-time = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ assert_eq!(ulid, res.unwrap());
 
 ## Crate Features
 
-* **`std` (default)**: Flag to toggle use of `std`, `rand`, and `time`. Disable this flag for `#[no_std]` support.
+* **`std` (default)**: Flag to toggle use of `std` and `rand`. Disable this flag for `#[no_std]` support.
 * **`serde`**: Enables serialization and deserialization of `Ulid` types via `serde`. ULIDs are serialized using their canonical 26-character representation as defined in the ULID standard. An optional `ulid_as_u128` module is provided, which enables serialization through an `Ulid`'s inner `u128` primitive type. See the [documentation][serde_mod] and [serde docs][serde_docs] for more information.
 * **`uuid`**: Implements infallible conversions between ULIDs and UUIDs from the [`uuid`][uuid] crate via the [`std::convert::From`][trait_from] trait.
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,9 +1,9 @@
 use bencher::{benchmark_group, benchmark_main, Bencher};
-use time::OffsetDateTime;
+use std::time::SystemTime;
 use ulid::{Generator, Ulid, ULID_LEN};
 
 fn bench_new(b: &mut Bencher) {
-    b.iter(|| Ulid::new());
+    b.iter(Ulid::new);
 }
 
 fn bench_generator_generate(b: &mut Bencher) {
@@ -12,7 +12,7 @@ fn bench_generator_generate(b: &mut Bencher) {
 }
 
 fn bench_from_time(b: &mut Bencher) {
-    let time = OffsetDateTime::now_utc();
+    let time = SystemTime::now();
     b.iter(|| Ulid::from_datetime(time));
 }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,3 +16,4 @@ edition = "2018"
 [dependencies]
 structopt = "0.2"
 ulid = { version = "*", path = ".." }
+time = "0.3.11"

--- a/cli/src/bin/ulid.rs
+++ b/cli/src/bin/ulid.rs
@@ -62,7 +62,7 @@ fn generate(count: u32, monotonic: bool) {
 
 fn inspect(values: &[String]) {
     for val in values {
-        let ulid = Ulid::from_string(&val);
+        let ulid = Ulid::from_string(val);
         match ulid {
             Ok(ulid) => {
                 let upper_hex = format!("{:X}", ulid.0);
@@ -81,7 +81,7 @@ COMPONENTS:
 ",
                     ulid.to_string(),
                     upper_hex,
-                    ulid.datetime(),
+                    time::OffsetDateTime::from(ulid.datetime()),
                     ulid.timestamp_ms(),
                     upper_hex.chars().skip(6).collect::<String>()
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,11 @@ struct ReadMeDoctest;
 
 mod base32;
 #[cfg(feature = "std")]
-mod time;
-#[cfg(feature = "std")]
 mod generator;
 #[cfg(feature = "serde")]
 pub mod serde;
+#[cfg(feature = "std")]
+mod time;
 #[cfg(feature = "uuid")]
 mod uuid;
 
@@ -145,13 +145,13 @@ impl Ulid {
     /// # Example
     /// ```rust
     /// # #[cfg(feature = "std")] {
-    /// use ::time::OffsetDateTime;
+    /// use std::time::{SystemTime, Duration};
     /// use ulid::Ulid;
     ///
-    /// let dt = OffsetDateTime::now_utc();
+    /// let dt = SystemTime::now();
     /// let ulid = Ulid::from_datetime(dt);
     ///
-    /// assert_eq!(ulid.timestamp_ms(), (dt.unix_timestamp_nanos() / 1_000_000) as u64);
+    /// assert_eq!(u128::from(ulid.timestamp_ms()), dt.duration_since(SystemTime::UNIX_EPOCH).unwrap_or(Duration::ZERO).as_millis());
     /// # }
     /// ```
     pub const fn timestamp_ms(&self) -> u64 {


### PR DESCRIPTION
This reduces a dependency, but also makes `ulid` compatible with all datetime libraries as the internal types generally implement `From<SystemTime>`.

This should also solve #52 and potentially #50 