### PR TITLE
All feature combinations compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "ulid"
 version = "1.0.0"
 authors = ["dylanhart <dylan96hart@gmail.com>"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.60"
 
 license = "MIT"
 readme = "README.md"
@@ -14,12 +15,12 @@ repository = "https://github.com/dylanhart/ulid-rs"
 
 [features]
 default = ["std"]
-std = ["rand"]
+std = ["rand", "serde?/std", "uuid?/std"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true, default-features = false }
 rand = { version = "0.8", optional = true }
-uuid = { version = "1.1", optional = true }
+uuid = { version = "1.1", optional = true, default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"
@@ -34,3 +35,4 @@ members = ["cli"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ulid-cli"
 version = "0.3.1"
 authors = ["dylanhart <dylan96hart@gmail.com>", "Kan-Ru Chen <kanru@kanru.info>"]
+rust-version = "1.60"
 
 license = "MIT"
 readme = "../README.md"
@@ -11,7 +12,7 @@ keywords = ["ulid", "uuid", "sortable", "identifier"]
 
 repository = "https://github.com/dylanhart/ulid-rs"
 
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 structopt = "0.2"

--- a/src/base32.rs
+++ b/src/base32.rs
@@ -45,6 +45,7 @@ pub enum EncodeError {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for EncodeError {}
 
 impl fmt::Display for EncodeError {
@@ -73,6 +74,7 @@ pub fn encode_to(mut value: u128, buffer: &mut [u8]) -> Result<usize, EncodeErro
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn encode(value: u128) -> String {
     let mut buffer: [u8; ULID_LEN] = [0; ULID_LEN];
 
@@ -91,6 +93,7 @@ pub enum DecodeError {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for DecodeError {}
 
 impl fmt::Display for DecodeError {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use crate::Ulid;
 
 /// A Ulid generator that provides monotonically increasing Ulids
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct Generator {
     previous: Ulid,
 }
@@ -152,6 +153,7 @@ impl Default for Generator {
 }
 
 /// Error while trying to generate a monotonic increment in the same millisecond
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum MonotonicError {
     /// Would overflow into the next millisecond

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //!
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[doc = include_str!("../README.md")]
 #[cfg(all(doctest, feature = "std"))]
@@ -39,6 +40,7 @@ mod base32;
 #[cfg(feature = "std")]
 mod generator;
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde;
 #[cfg(feature = "std")]
 mod time;
@@ -206,6 +208,7 @@ impl Ulid {
     /// ```
     #[allow(clippy::inherent_to_string_shadow_display)] // Significantly faster than Display::to_string
     #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn to_string(&self) -> String {
         base32::encode(self.0)
     }
@@ -281,6 +284,7 @@ impl Default for Ulid {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<Ulid> for String {
     fn from(ulid: Ulid) -> String {
         ulid.to_string()

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,9 @@
 use crate::{bitmask, Ulid};
 use std::time::{Duration, SystemTime};
 
+/// The standard library can be used to get the current time.
+/// The `std` feature (which is enabled by default) will expose some extra functions to make life easier.
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Ulid {
     /// Creates a new Ulid with the current time (UTC)
     ///
@@ -10,6 +13,7 @@ impl Ulid {
     ///
     /// let my_ulid = Ulid::new();
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn new() -> Ulid {
         Ulid::from_datetime(SystemTime::now())
     }
@@ -24,6 +28,7 @@ impl Ulid {
     /// let mut rng = StdRng::from_entropy();
     /// let ulid = Ulid::with_source(&mut rng);
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn with_source<R: rand::Rng>(source: &mut R) -> Ulid {
         Ulid::from_datetime_with_source(SystemTime::now(), source)
     }
@@ -42,6 +47,7 @@ impl Ulid {
     ///
     /// let ulid = Ulid::from_datetime(SystemTime::now());
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_datetime(datetime: SystemTime) -> Ulid {
         Ulid::from_datetime_with_source(datetime, &mut rand::thread_rng())
     }
@@ -60,6 +66,7 @@ impl Ulid {
     /// let mut rng = StdRng::from_entropy();
     /// let ulid = Ulid::from_datetime_with_source(SystemTime::now(), &mut rng);
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_datetime_with_source<R>(datetime: SystemTime, source: &mut R) -> Ulid
     where
         R: rand::Rng + ?Sized,
@@ -90,6 +97,7 @@ impl Ulid {
     ///     && dt - Duration::from_millis(1) <= ulid.datetime()
     /// );
     /// ```
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn datetime(&self) -> SystemTime {
         let stamp = self.timestamp_ms();
         SystemTime::UNIX_EPOCH + Duration::from_millis(stamp)

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -3,12 +3,14 @@
 use crate::Ulid;
 use uuid::Uuid;
 
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]
 impl From<Uuid> for Ulid {
     fn from(uuid: Uuid) -> Self {
         Ulid(uuid.as_u128())
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "uuid")))]
 impl From<Ulid> for Uuid {
     fn from(ulid: Ulid) -> Self {
         Uuid::from_u128(ulid.0)
@@ -21,7 +23,14 @@ mod test {
 
     #[test]
     fn uuid_cycle() {
+        #[cfg(feature = "std")]
         let ulid = Ulid::new();
+        #[cfg(not(feature = "std"))]
+        let ulid = Ulid::from_parts(
+            0x0000_1020_3040_5060_u64,
+            0x0000_0000_0000_0102_0304_0506_0708_090A_u128,
+        );
+
         let uuid: Uuid = ulid.into();
         let ulid2: Ulid = uuid.into();
 
@@ -32,11 +41,17 @@ mod test {
     fn uuid_str_cycle() {
         let uuid_txt = "771a3bce-02e9-4428-a68e-b1e7e82b7f9f";
         let ulid_txt = "3Q38XWW0Q98GMAD3NHWZM2PZWZ";
+        let mut buf = uuid::Uuid::encode_buffer();
 
         let ulid: Ulid = Uuid::parse_str(uuid_txt).unwrap().into();
-        assert_eq!(ulid.to_string(), ulid_txt);
+        let ulid_str = ulid.to_str(&mut buf).unwrap();
+        assert_eq!(ulid_str, ulid_txt);
+
+        #[cfg(feature = "std")]
+        assert_eq!(ulid.to_string().as_str(), ulid_txt);
 
         let uuid: Uuid = ulid.into();
-        assert_eq!(uuid.to_string(), uuid_txt);
+        let uuid_str = uuid.hyphenated().encode_lower(&mut buf);
+        assert_eq!(uuid_str, uuid_txt);
     }
 }


### PR DESCRIPTION
It was previously possible to disable the default `std` feature which caused the compilation to fail if the `serde` or `uuid` features were active. There were also tests which caused compilation errors when not building tests with the `std` feature.

This will however require rust 1.60 or higher due to the use of weak dependency features (i.e. `std = ["rand", "serde?/std", "uuid?/std"]`). This is a bump from the previous need for somewhere around 1.46-1.54 depending on compilation parameters. The documentation is also extended to include which features are needed for specific `fn`s.

The new implementation for `serde` no longer does any heap allocation, so it is completely safe to use in a `no_std` context. It can also sneakily deserialize all reasonable kinds of data without the need to override with `deserialize_with` if the `Deserializer` supports it.

Fixes #57 and the [specific use case](https://github.com/dylanhart/ulid-rs/issues/52#issuecomment-1243674163) in #52.