### PR TITLE
Add JS/Wasm compatibility (using the wasm-timer crate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 rand = { version = "0.8", optional = true }
 uuid = { version = "1.1", optional = true }
 
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+wasm-timer = "0.2"
+
 [dev-dependencies]
 bencher = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/dylanhart/ulid-rs"
 [features]
 default = ["std"]
 std = ["rand"]
-wasm = ["getrandom", "wasm-timer"]
+js = ["getrandom", "wasm-timer"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ repository = "https://github.com/dylanhart/ulid-rs"
 [features]
 default = ["std"]
 std = ["rand"]
+wasm = ["getrandom", "wasm-timer"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
 rand = { version = "0.8", optional = true }
 uuid = { version = "1.1", optional = true }
 
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-wasm-timer = "0.2"
+getrandom = { version = "0.2", features = ["js"], optional = true }
+wasm-timer = { version = "0.2", optional = true }
 
 [dev-dependencies]
 bencher = "0.1"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,4 +1,9 @@
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+
+#[cfg(not(target = "wasm32-unknown-unknown"))]
+use std::time::SystemTime;
+#[cfg(target = "wasm32-unknown-unknown")]
+use wasm_timer::SystemTime;
 
 use std::fmt;
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-#[cfg(not(target = "wasm32-unknown-unknown"))]
+#[cfg(not(feature = "wasm"))]
 use std::time::SystemTime;
-#[cfg(target = "wasm32-unknown-unknown")]
+#[cfg(feature = "wasm")]
 use wasm_timer::SystemTime;
 
 use std::fmt;

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(feature = "js"))]
 use std::time::SystemTime;
-#[cfg(feature = "wasm")]
+#[cfg(feature = "js")]
 use wasm_timer::SystemTime;
 
 use std::fmt;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,9 +1,9 @@
 use crate::{bitmask, Ulid};
 use std::time::Duration;
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(feature = "js"))]
 use std::time::SystemTime;
-#[cfg(feature = "wasm")]
+#[cfg(feature = "js")]
 use wasm_timer::SystemTime;
 
 impl Ulid {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,10 @@
 use crate::{bitmask, Ulid};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+
+#[cfg(not(target = "wasm32-unknown-unknown"))]
+use std::time::SystemTime;
+#[cfg(target = "wasm32-unknown-unknown")]
+use wasm_timer::SystemTime;
 
 impl Ulid {
     /// Creates a new Ulid with the current time (UTC)
@@ -11,7 +16,7 @@ impl Ulid {
     /// let my_ulid = Ulid::new();
     /// ```
     pub fn new() -> Ulid {
-        Ulid::from_datetime(SystemTime::now())
+        Self::from_datetime(SystemTime::now())
     }
 
     /// Creates a new Ulid using data from the given random number generator

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,9 +1,9 @@
 use crate::{bitmask, Ulid};
 use std::time::Duration;
 
-#[cfg(not(target = "wasm32-unknown-unknown"))]
+#[cfg(not(feature = "wasm"))]
 use std::time::SystemTime;
-#[cfg(target = "wasm32-unknown-unknown")]
+#[cfg(feature = "wasm")]
 use wasm_timer::SystemTime;
 
 impl Ulid {


### PR DESCRIPTION
As it is, this package does not work with the wasm32-unknown-unknown target. This adds support for it by bringing in an optional dependency on [wasm-timer](https://crates.io/crates/wasm-timer) that implements an equivalent of the `SystemTime` type using JS's `DateTime.now()` under the hood.
This PR also adds a `js` feature that will enable said support. This is similar to what the [uuid](https://github.com/uuid-rs/uuid) package does.