### PR TITLE
Make serde feature not depend on serde_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,13 @@ default = ["std"]
 std = ["rand"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", optional = true }
 rand = { version = "0.8", optional = true }
 uuid = { version = "1.1", optional = true }
 
 [dev-dependencies]
 bencher = "0.1"
+serde_derive = "1.0"
 
 [[bench]]
 name = "bench"

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -41,7 +41,7 @@ impl<'de> Deserialize<'de> for Ulid {
 /// ```
 /// # use ulid::Ulid;
 /// # use ulid::serde::ulid_as_u128;
-/// # use serde::{Serialize, Deserialize};
+/// # use serde_derive::{Serialize, Deserialize};
 /// #[derive(Serialize, Deserialize)]
 /// struct U128Example {
 ///     #[serde(with = "ulid_as_u128")]
@@ -81,7 +81,7 @@ pub mod ulid_as_u128 {
 /// ```
 /// # use ulid::Ulid;
 /// # use ulid::serde::ulid_as_uuid;
-/// # use serde::{Serialize, Deserialize};
+/// # use serde_derive::{Serialize, Deserialize};
 /// #[derive(Serialize, Deserialize)]
 /// struct UuidExample {
 ///     #[serde(with = "ulid_as_uuid")]


### PR DESCRIPTION
This change makes `ulid` not depend on `serde_derive` with the `serde` feature enabled, taking compilation with the feature enabled from `5.98s` to `2.37s` (ryzen 2600).

Accommodations have been made for the places where the derive feature is used in doc tests (by adding `serde_derive` as a dev dependency), the drawback of this is serde_derive is compiled unconditionally under any modes that make use of dev-dependencies (optional dev dependencies is not a thing, but if someone who knows more can figure it out that would be appreciated), but I believe the benefit of not compiling `serde_derive` for normal users of the crate (when they don't need it to run the serde related library code) is worthwhile.

This change has been made possible by the implicit coupling of serde and serde_derive versions (without using the "derive" feature) that was introduced in `serde 1.0.186`