### PR TITLE
Add Wasm tests running with wasm-bindgen-test

### DIFF
--- a/.github/curl_options
+++ b/.github/curl_options
@@ -1,0 +1,6 @@
+--fail
+--location
+--retry 3
+--retry-connrefused
+--show-error
+--silent

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,9 @@
 name: ci-build
 on: [push, pull_request]
+
+env:
+  WASM_PACK_VERSION: 0.12.1
+
 jobs:
   do-build:
     runs-on: ubuntu-latest
@@ -14,3 +18,20 @@ jobs:
       - run: cargo test --no-default-features --features=std
       - run: cargo test --no-default-features
 
+      - name: Create a directory for binary dependencies
+        shell: bash
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Install wasm-pack
+        working-directory: ${{ github.workspace }}/bin
+        shell: bash
+        run: |
+          file_name="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
+          curl \
+            --config ${GITHUB_WORKSPACE}/.github/curl_options \
+            https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${file_name}.tar.gz \
+            | tar --strip-components=1 -xzvf- "${file_name}/wasm-pack"
+
+      - run: wasm-pack test --node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ web-time = "1"
 bencher = "0.1"
 serde_derive = "1.0"
 
+[target.wasm32-unknown-unknown.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [[bench]]
 name = "bench"
 path = "benches/bench.rs"

--- a/src/time_utils.rs
+++ b/src/time_utils.rs
@@ -1,9 +1,9 @@
 pub(crate) fn now() -> std::time::SystemTime {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         use web_time::web::SystemTimeExt;
         return web_time::SystemTime::now().to_std();
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     return std::time::SystemTime::now();
 }

--- a/tests/wasm32-datetime.rs
+++ b/tests/wasm32-datetime.rs
@@ -1,0 +1,78 @@
+#![cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+
+use ulid::Ulid;
+
+use wasm_bindgen_test::*;
+use web_time::web::SystemTimeExt;
+
+use std::time::{Duration, SystemTime};
+
+fn now() -> std::time::SystemTime {
+    return web_time::SystemTime::now().to_std();
+}
+
+#[wasm_bindgen_test]
+fn test_dynamic() {
+    let ulid = Ulid::new();
+    let encoded = ulid.to_string();
+    let ulid2 = Ulid::from_string(&encoded).expect("failed to deserialize");
+
+    println!("{}", encoded);
+    println!("{:?}", ulid);
+    println!("{:?}", ulid2);
+    assert_eq!(ulid, ulid2);
+}
+
+#[wasm_bindgen_test]
+fn test_source() {
+    use rand::rngs::mock::StepRng;
+    let mut source = StepRng::new(123, 0);
+
+    let u1 = Ulid::with_source(&mut source);
+    let dt = now() + Duration::from_millis(1);
+    let u2 = Ulid::from_datetime_with_source(dt, &mut source);
+    let u3 = Ulid::from_datetime_with_source(dt, &mut source);
+
+    assert!(u1 < u2);
+    assert_eq!(u2, u3);
+}
+
+#[wasm_bindgen_test]
+fn test_order() {
+    let dt = now();
+    let ulid1 = Ulid::from_datetime(dt);
+    let ulid2 = Ulid::from_datetime(dt + Duration::from_millis(1));
+    assert!(ulid1 < ulid2);
+}
+
+#[wasm_bindgen_test]
+fn test_datetime() {
+    let dt = now();
+    let ulid = Ulid::from_datetime(dt);
+
+    println!("{:?}, {:?}", dt, ulid.datetime());
+    assert!(ulid.datetime() <= dt);
+    assert!(ulid.datetime() + Duration::from_millis(1) >= dt);
+}
+
+#[wasm_bindgen_test]
+fn test_timestamp() {
+    let dt = now();
+    let ulid = Ulid::from_datetime(dt);
+    let ts = dt
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    assert_eq!(u128::from(ulid.timestamp_ms()), ts);
+}
+
+#[wasm_bindgen_test]
+fn default_is_nil() {
+    assert_eq!(Ulid::default(), Ulid::nil());
+}
+
+#[wasm_bindgen_test]
+fn nil_is_at_unix_epoch() {
+    assert_eq!(Ulid::nil().datetime(), SystemTime::UNIX_EPOCH);
+}


### PR DESCRIPTION
```
running 7 tests
test wasm32_datetime::nil_is_at_unix_epoch ... ok
test wasm32_datetime::default_is_nil ... ok
test wasm32_datetime::test_timestamp ... ok
test wasm32_datetime::test_datetime ... ok
test wasm32_datetime::test_order ... ok
test wasm32_datetime::test_source ... ok
test wasm32_datetime::test_dynamic ... ok
test result: ok. 7 passed; 0 failed; 0 ignored
```

Unfortunately, I had to add them as a new test module because the runner won't pick them up otherwise. See [the last sentence](https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/usage.html#write-some-tests) of this guide.