### PR TITLE
Add TryFrom impls for Ulid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,14 +365,6 @@ impl TryFrom<&'_ str> for Ulid {
     }
 }
 
-impl TryFrom<String> for Ulid {
-    type Error = DecodeError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ulid::from_string(&value)
-    }
-}
-
 impl fmt::Display for Ulid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         let mut buffer = [0; ULID_LEN];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod time_utils;
 #[cfg(feature = "uuid")]
 mod uuid;
 
+use core::convert::TryFrom;
 use core::fmt;
 use core::str::FromStr;
 
@@ -353,6 +354,22 @@ impl FromStr for Ulid {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ulid::from_string(s)
+    }
+}
+
+impl TryFrom<&'_ str> for Ulid {
+    type Error = DecodeError;
+
+    fn try_from(value: &'_ str) -> Result<Self, Self::Error> {
+        Ulid::from_string(value)
+    }
+}
+
+impl TryFrom<String> for Ulid {
+    type Error = DecodeError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Ulid::from_string(&value)
     }
 }
 


### PR DESCRIPTION
[Analogous to Uuid](https://docs.rs/uuid/latest/uuid/struct.Uuid.html#impl-TryFrom%3C%26str%3E-for-Uuid), this PR adds `TryFrom<&str>` ~~and `TryFrom<String>`~~ implementations for the `Ulid` type.