### PR TITLE
Make an optional js feature

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,4 +34,4 @@ jobs:
             https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${file_name}.tar.gz \
             | tar --strip-components=1 -xzvf- "${file_name}/wasm-pack"
 
-      - run: wasm-pack test --node
+      - run: wasm-pack test --node --features js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/dylanhart/ulid-rs"
 default = ["std"]
 std = ["rand"]
 postgres = ["dep:postgres-types", "dep:bytes"]
+js = ["getrandom/js"]
 
 [dependencies]
 serde = { version = "1.0", optional = true }
@@ -25,7 +26,7 @@ postgres-types = { version = "0.2.6", optional = true }
 bytes = { version = "1.4.0", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = "0.2"
 web-time = "1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ assert_eq!(ulid, res.unwrap());
 * **`std` (default)**: Flag to toggle use of `std` and `rand`. Disable this flag for `#[no_std]` support.
 * **`serde`**: Enables serialization and deserialization of `Ulid` types via `serde`. ULIDs are serialized using their canonical 26-character representation as defined in the ULID standard. An optional `ulid_as_u128` module is provided, which enables serialization through an `Ulid`'s inner `u128` primitive type. See the [documentation][serde_mod] and [serde docs][serde_docs] for more information.
 * **`uuid`**: Implements infallible conversions between ULIDs and UUIDs from the [`uuid`][uuid] crate via the [`std::convert::From`][trait_from] trait.
+* **`js`**: Flag that turns on the `getrandom/js` feature, which is only used for wasm32 targets.
 
 [serde_mod]: https://docs.rs/ulid/latest/ulid/serde/index.html
 [serde_docs]: https://serde.rs/field-attrs.html#with


### PR DESCRIPTION
When the target is wasm32, the current configuration would by default enable the "js" feature of getrandom. 
But this won't work well with projects that cannot enable the "js" feature (e.g., those use the "custom" feature).

Because cargo features are additive, it is best to avoid setting the "js" feature as default, but instead make it optional.
