### PR TITLE
make getrandom dependency optional

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,4 +34,4 @@ jobs:
             https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${file_name}.tar.gz \
             | tar --strip-components=1 -xzvf- "${file_name}/wasm-pack"
 
-      - run: wasm-pack test --node
+      - run: wasm-pack test --node --features getrandom/js

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ postgres-types = { version = "0.2.6", optional = true }
 bytes = { version = "1.4.0", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.2", optional = true }
 web-time = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
The `getrandom` crate wasn't directly used by `ulid`, and only in testing `wasm-pack` requires it and its `js` feature.
The fix is to make it optional, and pass correct flags to `wasm-pack` command.