### PR TITLE
make getrandom a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ postgres-types = { version = "0.2.6", optional = true }
 bytes = { version = "1.4.0", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
 web-time = "1"
 
 [dev-dependencies]
@@ -33,6 +32,7 @@ bencher = "0.1"
 serde_derive = "1.0"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3"
 
 [[bench]]


### PR DESCRIPTION
The ulid crate does not use getrandom at all, and it is only useful in running tests with `wasm-pack`.
So moving it to a dev dependency will help other packages to avoid enabling the `getrandom/js` feature by default.

If needed, a package can still choose to add getrandom as a dependency and enable the js feature.