### PR TITLE
Install wasm-pack using cargo and choose nodejs version 20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,14 +1,14 @@
 name: ci-build
 on: [push, pull_request]
 
-env:
-  WASM_PACK_VERSION: 0.12.1
-
 jobs:
   do-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -18,20 +18,10 @@ jobs:
       - run: cargo test --no-default-features --features=std
       - run: cargo test --no-default-features
 
-      - name: Create a directory for binary dependencies
-        shell: bash
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
       - name: Install wasm-pack
-        working-directory: ${{ github.workspace }}/bin
         shell: bash
         run: |
-          file_name="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
-          curl \
-            --config ${GITHUB_WORKSPACE}/.github/curl_options \
-            https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${file_name}.tar.gz \
-            | tar --strip-components=1 -xzvf- "${file_name}/wasm-pack"
+          cargo install wasm-pack
+          ls -l ~/.cargo/bin/
 
-      - run: wasm-pack test --node
+      - run: ~/.cargo/bin/wasm-pack test --node

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,9 +19,6 @@ jobs:
       - run: cargo test --no-default-features
 
       - name: Install wasm-pack
-        shell: bash
-        run: |
-          cargo install wasm-pack
-          ls -l ~/.cargo/bin/
+        run: cargo install wasm-pack
 
       - run: ~/.cargo/bin/wasm-pack test --node


### PR DESCRIPTION
Fix the broken CI by installing nodejs version 20 instead of using the default.

Also simplify wasm-pack installation by using cargo install. 