### PR TITLE
Upgrade rand to v0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bencher = "0.1"
 serde_derive = "1.0"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
-getrandom = { version = "0.3.1", features = ["wasm_js"] }
+getrandom = { version = "0.4.2", features = ["wasm_js"] }
 wasm-bindgen-test = "0.3"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ repository = "https://github.com/dylanhart/ulid-rs"
 
 [features]
 default = ["std"]
-std = ["rand"]
+std = ["dep:rand"]
 postgres = ["dep:postgres-types", "dep:bytes"]
 rkyv = ["dep:rkyv"]
 
 [dependencies]
 serde = { version = "1.0", optional = true }
-rand = { version = "0.9", optional = true }
+rand = { version = "0.10", optional = true }
 uuid = { version = "1.1", optional = true }
 postgres-types = { version = "0.2.6", optional = true }
 bytes = { version = "1.4.0", optional = true }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -76,9 +76,9 @@ impl Generator {
     /// use ulid::Generator;
     /// use ulid::Ulid;
     /// use std::time::SystemTime;
-    /// use rand::prelude::*;
+    /// use rand::{prelude::*, rngs::SysRng};
     ///
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = StdRng::try_from_rng(&mut SysRng).unwrap();
     /// let mut gen = Generator::new();
     ///
     /// let ulid1 = gen.generate_with_source(&mut rng).unwrap();
@@ -101,10 +101,10 @@ impl Generator {
     /// ```rust
     /// use ulid::Generator;
     /// use std::time::SystemTime;
-    /// use rand::prelude::*;
+    /// use rand::{prelude::*, rngs::SysRng};
     ///
     /// let dt = SystemTime::now();
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = StdRng::try_from_rng(&mut SysRng).unwrap();
     /// let mut gen = Generator::new();
     ///
     /// let ulid1 = gen.generate_from_datetime_with_source(dt, &mut rng).unwrap();

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -186,14 +186,14 @@ mod tests {
 
     #[test]
     fn test_order_monotonic_with_source() {
-        use rand::rngs::mock::StepRng;
-        let mut source = StepRng::new(123, 0);
+        use rand::{rngs::SmallRng, SeedableRng as _};
+        let mock_source = || SmallRng::seed_from_u64(1);
         let mut gen = Generator::new();
 
         let _has_default = Generator::default();
 
-        let ulid1 = gen.generate_with_source(&mut source).unwrap();
-        let ulid2 = gen.generate_with_source(&mut source).unwrap();
+        let ulid1 = gen.generate_with_source(&mut mock_source()).unwrap();
+        let ulid2 = gen.generate_with_source(&mut mock_source()).unwrap();
         assert!(ulid1 < ulid2);
     }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -64,7 +64,7 @@ impl Ulid {
     /// ```
     pub fn from_datetime_with_source<R>(datetime: SystemTime, source: &mut R) -> Ulid
     where
-        R: rand::Rng + ?Sized,
+        R: rand::RngExt + ?Sized,
     {
         let timestamp = datetime
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -116,13 +116,13 @@ mod tests {
 
     #[test]
     fn test_source() {
-        use rand::rngs::mock::StepRng;
-        let mut source = StepRng::new(123, 0);
+        use rand::{rngs::SmallRng, SeedableRng as _};
+        let mock_source = || SmallRng::seed_from_u64(1);
 
-        let u1 = Ulid::with_source(&mut source);
+        let u1 = Ulid::with_source(&mut mock_source());
         let dt = SystemTime::now() + Duration::from_millis(1);
-        let u2 = Ulid::from_datetime_with_source(dt, &mut source);
-        let u3 = Ulid::from_datetime_with_source(dt, &mut source);
+        let u2 = Ulid::from_datetime_with_source(dt, &mut mock_source());
+        let u3 = Ulid::from_datetime_with_source(dt, &mut mock_source());
 
         assert!(u1 < u2);
         assert_eq!(u2, u3);

--- a/src/time.rs
+++ b/src/time.rs
@@ -20,10 +20,10 @@ impl Ulid {
     ///
     /// # Example
     /// ```rust
-    /// use rand::prelude::*;
+    /// use rand::{prelude::*, rngs::SysRng};
     /// use ulid::Ulid;
     ///
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = StdRng::try_from_rng(&mut SysRng).unwrap();
     /// let ulid = Ulid::with_source(&mut rng);
     /// ```
     pub fn with_source<R: rand::Rng>(source: &mut R) -> Ulid {
@@ -56,10 +56,10 @@ impl Ulid {
     /// # Example
     /// ```rust
     /// use std::time::{SystemTime, Duration};
-    /// use rand::prelude::*;
+    /// use rand::{prelude::*, rngs::SysRng};
     /// use ulid::Ulid;
     ///
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = StdRng::try_from_rng(&mut SysRng).unwrap();
     /// let ulid = Ulid::from_datetime_with_source(SystemTime::now(), &mut rng);
     /// ```
     pub fn from_datetime_with_source<R>(datetime: SystemTime, source: &mut R) -> Ulid

--- a/tests/wasm32-datetime.rs
+++ b/tests/wasm32-datetime.rs
@@ -25,13 +25,13 @@ fn test_dynamic() {
 
 #[wasm_bindgen_test]
 fn test_source() {
-    use rand::rngs::mock::StepRng;
-    let mut source = StepRng::new(123, 0);
+    use rand::{rngs::SmallRng, SeedableRng as _};
+    let mock_source = || SmallRng::seed_from_u64(123);
 
-    let u1 = Ulid::with_source(&mut source);
+    let u1 = Ulid::with_source(&mut mock_source());
     let dt = now() + Duration::from_millis(1);
-    let u2 = Ulid::from_datetime_with_source(dt, &mut source);
-    let u3 = Ulid::from_datetime_with_source(dt, &mut source);
+    let u2 = Ulid::from_datetime_with_source(dt, &mut mock_source());
+    let u3 = Ulid::from_datetime_with_source(dt, &mut mock_source());
 
     assert!(u1 < u2);
     assert_eq!(u2, u3);


### PR DESCRIPTION
- Replace `Rng` with `RngExt`.
- Replace `StepRng` with `SmallRng` and fixed initial state.