### PR TITLE
chore: bump ulid to use rand 0.10 and bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.0.0
+
+### Changed
+
+- Bumped `rand` dependency to 0.10. The trait bound on `with_source`, `from_datetime_with_source`, `generate_with_source`, and `generate_from_datetime_with_source` changed from `rand::Rng` to `rand::RngExt` due to upstream renaming in rand 0.10.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ulid"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["dylanhart <dylan96hart@gmail.com>"]
 edition = "2018"
 
@@ -20,7 +20,7 @@ rkyv = ["dep:rkyv"]
 
 [dependencies]
 serde = { version = "1.0", optional = true }
-rand = { version = "0.9", optional = true }
+rand = { version = "0.10", optional = true }
 uuid = { version = "1.1", optional = true }
 postgres-types = { version = "0.2.6", optional = true }
 bytes = { version = "1.4.0", optional = true }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -78,7 +78,7 @@ impl Generator {
     /// use std::time::SystemTime;
     /// use rand::prelude::*;
     ///
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = rand::make_rng::<StdRng>();
     /// let mut gen = Generator::new();
     ///
     /// let ulid1 = gen.generate_with_source(&mut rng).unwrap();
@@ -88,7 +88,7 @@ impl Generator {
     /// ```
     pub fn generate_with_source<R>(&mut self, source: &mut R) -> Result<Ulid, MonotonicError>
     where
-        R: rand::Rng + ?Sized,
+        R: rand::RngExt + ?Sized,
     {
         self.generate_from_datetime_with_source(crate::time_utils::now(), source)
     }
@@ -104,7 +104,7 @@ impl Generator {
     /// use rand::prelude::*;
     ///
     /// let dt = SystemTime::now();
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = rand::make_rng::<StdRng>();
     /// let mut gen = Generator::new();
     ///
     /// let ulid1 = gen.generate_from_datetime_with_source(dt, &mut rng).unwrap();
@@ -119,7 +119,7 @@ impl Generator {
         source: &mut R,
     ) -> Result<Ulid, MonotonicError>
     where
-        R: rand::Rng + ?Sized,
+        R: rand::RngExt + ?Sized,
     {
         let last_ms = self.previous.timestamp_ms();
         // maybe time went backward, or it is the same ms.
@@ -186,8 +186,9 @@ mod tests {
 
     #[test]
     fn test_order_monotonic_with_source() {
-        use rand::rngs::mock::StepRng;
-        let mut source = StepRng::new(123, 0);
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+        let mut source = StdRng::seed_from_u64(123);
         let mut gen = Generator::new();
 
         let _has_default = Generator::default();

--- a/src/rkyv.rs
+++ b/src/rkyv.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tests {
     use crate::Ulid;
-    use rkyv::{{from_bytes, to_bytes}, rancor::Error};
+    use rkyv::{
+        rancor::Error,
+        {from_bytes, to_bytes},
+    };
 
     #[test]
     fn test_ulid_roundtrip() {

--- a/src/time.rs
+++ b/src/time.rs
@@ -23,10 +23,10 @@ impl Ulid {
     /// use rand::prelude::*;
     /// use ulid::Ulid;
     ///
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = rand::make_rng::<StdRng>();
     /// let ulid = Ulid::with_source(&mut rng);
     /// ```
-    pub fn with_source<R: rand::Rng>(source: &mut R) -> Ulid {
+    pub fn with_source<R: rand::RngExt>(source: &mut R) -> Ulid {
         Ulid::from_datetime_with_source(crate::time_utils::now(), source)
     }
 
@@ -59,12 +59,12 @@ impl Ulid {
     /// use rand::prelude::*;
     /// use ulid::Ulid;
     ///
-    /// let mut rng = StdRng::from_os_rng();
+    /// let mut rng = rand::make_rng::<StdRng>();
     /// let ulid = Ulid::from_datetime_with_source(SystemTime::now(), &mut rng);
     /// ```
     pub fn from_datetime_with_source<R>(datetime: SystemTime, source: &mut R) -> Ulid
     where
-        R: rand::Rng + ?Sized,
+        R: rand::RngExt + ?Sized,
     {
         let timestamp = datetime
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -100,6 +100,7 @@ impl Ulid {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
@@ -116,8 +117,27 @@ mod tests {
 
     #[test]
     fn test_source() {
-        use rand::rngs::mock::StepRng;
-        let mut source = StepRng::new(123, 0);
+        use rand::rand_core::TryRng;
+        use std::convert::Infallible;
+
+        // see https://github.com/rust-random/rand/blob/54e5eaaa7ac11af3aa60b5ccc486182189e6f9ef/src/lib.rs#L352
+        struct StepRng(u64, u64);
+        impl TryRng for StepRng {
+            type Error = Infallible;
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+                self.try_next_u64().map(|x| x as u32)
+            }
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                let res = self.0;
+                self.0 = self.0.wrapping_add(self.1);
+                Ok(res)
+            }
+            fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Infallible> {
+                rand::rand_core::utils::fill_bytes_via_next_word(dst, || self.try_next_u64())
+            }
+        }
+
+        let mut source = StepRng(123, 0);
 
         let u1 = Ulid::with_source(&mut source);
         let dt = SystemTime::now() + Duration::from_millis(1);


### PR DESCRIPTION
This PR bumps the dependency version of `rand` to `0.10`  to keep up with their changes. 

Since `rand`'s changes are breaking (even though a minor version) the bounds of `R` becomes `RngExt` instead of `Rng` thus being a breaking change.

I've added a CHANGELOG.md to track this.