### PR TITLE
Reject overflowing ULID strings instead of silently truncating

### DIFF
--- a/src/base32.rs
+++ b/src/base32.rs
@@ -78,11 +78,14 @@ pub fn encode(value: u128) -> String {
 
 /// An error that can occur when decoding a base32 string
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[non_exhaustive]
 pub enum DecodeError {
     /// The length of the string does not match the expected length
     InvalidLength,
     /// A non-base32 character was found
     InvalidChar,
+    /// The value encoded by the string does not fit in 128 bits
+    Overflow,
 }
 
 #[cfg(feature = "std")]
@@ -93,6 +96,7 @@ impl fmt::Display for DecodeError {
         let text = match *self {
             DecodeError::InvalidLength => "invalid length",
             DecodeError::InvalidChar => "invalid character",
+            DecodeError::Overflow => "overflowing value",
         };
         write!(f, "{}", text)
     }
@@ -106,6 +110,14 @@ pub const fn decode(encoded: &str) -> Result<u128, DecodeError> {
     let mut value: u128 = 0;
 
     let bytes = encoded.as_bytes();
+
+    // 26 base32 chars carry 130 bits but a Ulid is 128, so the leading char
+    // must fit in the top 2 bits (<= 7) or the value overflows and wraps (#59).
+    // NO_VALUE falls through to the loop, which reports it as InvalidChar.
+    let high = LOOKUP[bytes[0] as usize];
+    if high != NO_VALUE && high > 7 {
+        return Err(DecodeError::Overflow);
+    }
 
     // Manual for loop because Range::iter() isn't const
     let mut i = 0;
@@ -180,6 +192,39 @@ mod tests {
         assert_eq!(
             decode("2D9RW50IA499CMAGHM6DD42DTP"),
             Err(DecodeError::InvalidChar)
+        );
+    }
+
+    #[test]
+    fn test_overflow() {
+        let max = format!("7{}", "Z".repeat(25));
+        let over_8 = format!("8{}", "Z".repeat(25));
+        let over_a = format!("A{}", "Z".repeat(25));
+        let over_z = "Z".repeat(26);
+        let bad_high = format!("I{}", "Z".repeat(25));
+        let smallest = format!("0{}", "Z".repeat(25));
+        for s in [&max, &over_8, &over_a, &over_z, &bad_high, &smallest] {
+            assert_eq!(s.len(), ULID_LEN);
+        }
+
+        // The largest valid ULID (all 128 bits set) still decodes and round-trips.
+        assert_eq!(decode(&max).unwrap(), u128::MAX);
+        assert_eq!(encode(u128::MAX), max);
+
+        // A leading char above '7' sets the 129th/130th bit. These used to
+        // truncate silently (8ZZ.. -> 0ZZ.., 26xZ -> 7ZZ..), aliasing distinct
+        // strings onto one id; now they are rejected.
+        assert_eq!(decode(&over_8), Err(DecodeError::Overflow));
+        assert_eq!(decode(&over_a), Err(DecodeError::Overflow));
+        assert_eq!(decode(&over_z), Err(DecodeError::Overflow));
+
+        // Overflow must not mask an invalid leading character.
+        assert_eq!(decode(&bad_high), Err(DecodeError::InvalidChar));
+
+        // The value 8ZZ.. used to alias onto still decodes on its own.
+        assert_eq!(
+            decode(&smallest).unwrap(),
+            0x1fffffffffffffffffffffffffffffff
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,6 +458,33 @@ mod tests {
     }
 
     #[test]
+    fn rejects_overflowing_strings_on_every_entry_point() {
+        // 8ZZ.. overflows 128 bits and previously truncated to 0ZZ..'s value,
+        // silently aliasing two distinct strings onto one id (#59). Every public
+        // string constructor routes through base32::decode, so all must reject.
+        let over = format!("8{}", "Z".repeat(25));
+        assert_eq!(Ulid::from_string(&over), Err(DecodeError::Overflow));
+        assert_eq!(over.parse::<Ulid>(), Err(DecodeError::Overflow));
+        assert_eq!(Ulid::try_from(over.as_str()), Err(DecodeError::Overflow));
+
+        // The value it used to collide with is valid and unchanged.
+        let small = format!("0{}", "Z".repeat(25));
+        assert_eq!(
+            Ulid::from_string(&small).unwrap().0,
+            0x1fffffffffffffffffffffffffffffff
+        );
+    }
+
+    #[test]
+    fn round_trip_is_canonical() {
+        let max = format!("7{}", "Z".repeat(25));
+        let nil = "0".repeat(26);
+        for s in [nil.as_str(), "21850M2GA1850M2GA1850M2GA1", max.as_str()] {
+            assert_eq!(Ulid::from_string(s).unwrap().to_string(), s);
+        }
+    }
+
+    #[test]
     fn can_display_things() {
         println!("{}", Ulid::nil());
         println!("{}", EncodeError::BufferTooSmall);


### PR DESCRIPTION
A 26-character Crockford base32 string encodes 130 bits, but a ULID is 128. `base32::decode` accumulates all 130 bits into a `u128`, so the top two bits of the leading character are shifted out and lost with no overflow check. As a result the crate:

- accepts over-max strings (any leading char above `7`), which the spec says to reject;
- breaks the round-trip: `to_string(from_string(s)) != s` for those inputs;
- aliases distinct strings onto one id — e.g. `8ZZ…Z` and `0ZZ…Z` both decode to `0x1fff…ff`, and 26×`Z` and `7ZZ…Z` both decode to `0xffff…ff`.

```rust
let a = Ulid::from_string("8ZZZZZZZZZZZZZZZZZZZZZZZZZZ").unwrap();
let b = Ulid::from_string("0ZZZZZZZZZZZZZZZZZZZZZZZZZZ").unwrap();
assert_eq!(a, b); // distinct strings, same ULID
```

The ULID spec and oklog/ulid both reject anything above `7ZZ…Z` ("overflow when unmarshaling") to prevent exactly this. This is issue #59.

The leading character occupies the top two bits, so it must be `<= 7` for the value to fit in 128 bits. `decode` now returns a new `DecodeError::Overflow` when it isn't. Every string constructor (`from_string`, `FromStr`, `TryFrom<&str>`, and the serde/postgres impls) routes through `decode`, so one guard covers them all; `encode` takes a `u128` and can't overflow. Valid ULIDs, including the max `7ZZ…Z`, still decode byte-for-byte.

Semver note: adding the `Overflow` variant is breaking. You flagged this in #59 ("a new error when parsing will require a major version bump"). I also marked `DecodeError` `#[non_exhaustive]` in the same change so future variants won't be breaking — happy to drop that if you'd prefer. The version bump is your call.

Tests: `test_overflow` in base32.rs (over-max rejected, invalid leading char still `InvalidChar`, max still decodes) plus `rejects_overflowing_strings_on_every_entry_point` and `round_trip_is_canonical` in lib.rs. `cargo test --all-features` passes.

Fixes #59
